### PR TITLE
Use io:format("~ts", ...) instead of stdout

### DIFF
--- a/src/ircbot_log.erl
+++ b/src/ircbot_log.erl
@@ -3,20 +3,11 @@
 
 -export([init/0, init/1, debug/1, debug/2]).
 
-%%
-%% Stupid and simple module that logs to stdout. The stdout port thing is needed so we can write Erlang binaries,
-%% no mather if they are utf, latin1 or something else. Seems no other function could do that in Erlang :(
-%%
-%% But, you can override* this module in your own project (that uses ircbot as a library/dependency).
-%% *override = create a module in your project with the same name as this, and make sure your project is
-%% before the dependecies in the ERL_LIBS path. Ex. ERL_LIBS=$PWD:$PWD/deps
-%%
-
 init() ->
     init([]).
 
 init(_) ->
-    open_stdout().
+    ok.
 
 %% debug helpers
 debug(in, Msg) ->
@@ -28,12 +19,4 @@ debug(out, Msg) ->
 % print directly to stdout thus avoid Erlangs broken
 % io:* routines
 debug(Msg) ->
-    port_command(stdout, [Msg, "\n"]).
-
-% open stdout as an Erlang port and register it with the
-% stdout atom. The port will be closed automatically if the
-% connection process dies.
-open_stdout() ->
-    StdOut = open_port("/dev/stdout", [binary, out]),
-    register(stdout, StdOut),
-    debug(["stdout ready for logging"]).
+    io:format("~ts\n", [Msg]).


### PR DESCRIPTION
`io:format` with `"~ts"` seems to handle unicode iolist
correctly, so use it instead of port_command.

Code is tested on erlang 17.0. It seems that unicode support for erlang is
introduced recently, so I'm not sure if `"~ts"` breaks compatibility with older
erlang releases.
