### PR TITLE
Added linebreaks in MAC OS X

### DIFF
--- a/src/ircbot_log.erl
+++ b/src/ircbot_log.erl
@@ -28,7 +28,7 @@ debug(out, Msg) ->
 % print directly to stdout thus avoid Erlangs broken
 % io:* routines
 debug(Msg) ->
-    port_command(stdout, [Msg, "\n"]).
+    port_command(stdout, [Msg, "\r\n"]).
 
 % open stdout as an Erlang port and register it with the
 % stdout atom. The port will be closed automatically if the


### PR DESCRIPTION
Linebreaks were not shown under OS X.